### PR TITLE
also use BaseTestNext on 0.5 prereleases

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 # Run package tests
 println("Testing Silo.jl in Julia version ", VERSION)
 
-if VERSION >= v"0.5-"
+if VERSION >= v"0.5"
   using Base.Test
 else
   using BaseTestNext


### PR DESCRIPTION
since early -dev versions wouldn't have at-testset